### PR TITLE
changed spec in student index to be more readable

### DIFF
--- a/spec/features/student_index_spec.rb
+++ b/spec/features/student_index_spec.rb
@@ -15,6 +15,6 @@ describe 'Multiple students are shown' do
 
     visit "/students"
 
-    expect(page).to have_content(/(?=.*Daenerys)(?=.*Lindsey).*/)
+    assert_text("Daenerys", "Lindsey")
   end
 end


### PR DESCRIPTION
I changed the test spec from: 
expect(page).to have_content(/(?=.*Daenerys)(?=.*Lindsey).*/)

to: 
assert_text("Daenerys", "Lindsey")

If we are expecting students to read test specs, we should have test specs that are clear for students to understand. Since our students are not very familiar with regex, I changed it to be a little clearer. This way of expressing the spec gives more clarity for students while at the same time providing the same level of flexibility in the spec. 