### PR TITLE
fixed rspec assert_text

### DIFF
--- a/spec/features/student_index_spec.rb
+++ b/spec/features/student_index_spec.rb
@@ -15,6 +15,6 @@ describe 'Multiple students are shown' do
 
     visit "/students"
 
-    assert_text('Daenerys') && assert_text ('Lindsey')
+    assert_text('Daenerys') && assert_text('Lindsey')
   end
 end

--- a/spec/features/student_index_spec.rb
+++ b/spec/features/student_index_spec.rb
@@ -15,6 +15,6 @@ describe 'Multiple students are shown' do
 
     visit "/students"
 
-    assert_text("Daenerys", "Lindsey")
+    assert_text('Daenerys') && assert_text ('Lindsey')
   end
 end


### PR DESCRIPTION
the original line 18 was failing with the following error

```Failures:

  1) Multiple students are shown on the index page
     Failure/Error: assert_text('Daenerys', 'Lindsey')

     ArgumentError:
       Daenerys is not a valid type for a text query
     # ./spec/features/student_index_spec.rb:18:in `block (2 levels) in <top (required)>'
```

per https://www.rubydoc.info/github/jnicklas/capybara/Capybara%2FNode%2FMatchers:assert_text, changed the formatting a little bit to two different `assert_text` calls